### PR TITLE
Add example server and root page

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -1,0 +1,2 @@
+import * as LaserMaceEngine from 'laser-mace-engine';
+console.log('LaserMaceEngine', LaserMaceEngine);

--- a/examples/app.ts
+++ b/examples/app.ts
@@ -1,0 +1,2 @@
+import * as LaserMaceEngine from 'laser-mace-engine';
+console.log('LaserMaceEngine', LaserMaceEngine);

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Laser Mace Engine Example</title>
+</head>
+<body>
+  <h1>Laser Mace Engine Example</h1>
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/examples/server.ts
+++ b/examples/server.ts
@@ -1,0 +1,37 @@
+import { createServer } from 'http';
+import { readFile } from 'fs';
+import { join } from 'path';
+
+const server = createServer((req, res) => {
+  if (!req.url || req.url === '/' || req.url === '/index.html') {
+    const filePath = join(__dirname, 'index.html');
+    readFile(filePath, (err, data) => {
+      if (err) {
+        res.statusCode = 500;
+        res.end('Internal Server Error');
+      } else {
+        res.setHeader('Content-Type', 'text/html');
+        res.end(data);
+      }
+    });
+  } else if (req.url === '/app.js') {
+    const filePath = join(__dirname, 'app.js');
+    readFile(filePath, (err, data) => {
+      if (err) {
+        res.statusCode = 404;
+        res.end('Not Found');
+      } else {
+        res.setHeader('Content-Type', 'application/javascript');
+        res.end(data);
+      }
+    });
+  } else {
+    res.statusCode = 404;
+    res.end('Not Found');
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a simple example server that serves `index.html` from the `examples` directory
- demonstrate importing the engine in `app.ts`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_68789a5930dc833086033b663e29e751