### PR TITLE
Add Rapier-based physics system

### DIFF
--- a/dist/engine/index.d.ts
+++ b/dist/engine/index.d.ts
@@ -4,3 +4,4 @@ export * from "./components/Velocity";
 export * from "./components/Mesh";
 export * from "./systems/MoveSystem";
 export * from "./systems/RenderSystem";
+export * from "./systems/PhysicsSystem";

--- a/dist/engine/index.js
+++ b/dist/engine/index.js
@@ -4,3 +4,4 @@ export * from "./components/Velocity";
 export * from "./components/Mesh";
 export * from "./systems/MoveSystem";
 export * from "./systems/RenderSystem";
+export * from "./systems/PhysicsSystem";

--- a/dist/engine/systems/PhysicsSystem.d.ts
+++ b/dist/engine/systems/PhysicsSystem.d.ts
@@ -1,0 +1,16 @@
+import { System } from "ecsy";
+export interface PhysicsSystemConfig {
+    gravity?: {
+        x: number;
+        y: number;
+        z: number;
+    };
+}
+export declare class PhysicsSystem extends System {
+    private rapier;
+    private physicsWorld;
+    private bodies;
+    init(attributes?: PhysicsSystemConfig): Promise<void>;
+    execute(_delta: number): void;
+    stop(): void;
+}

--- a/dist/engine/systems/PhysicsSystem.js
+++ b/dist/engine/systems/PhysicsSystem.js
@@ -1,0 +1,57 @@
+import { System } from "ecsy";
+import RAPIER from "@dimforge/rapier3d-compat";
+import { Position } from "../components/Position";
+import { Velocity } from "../components/Velocity";
+export class PhysicsSystem extends System {
+    constructor() {
+        super(...arguments);
+        this.bodies = new Map();
+    }
+    async init(attributes) {
+        this.rapier = await RAPIER.init();
+        const gravity = attributes?.gravity ?? { x: 0, y: -9.81, z: 0 };
+        this.physicsWorld = new this.rapier.World(gravity);
+    }
+    execute(_delta) {
+        // create bodies for newly added entities
+        if (this.queries.movers?.added) {
+            this.queries.movers.added.forEach((entity) => {
+                const pos = entity.getComponent(Position);
+                const desc = this.rapier.RigidBodyDesc.newDynamic().setTranslation(pos.x, pos.y, pos.z);
+                const body = this.physicsWorld.createRigidBody(desc);
+                this.bodies.set(entity, body);
+            });
+        }
+        // update bodies with velocity from components
+        this.queries.movers.results.forEach((entity) => {
+            const vel = entity.getComponent(Velocity);
+            const body = this.bodies.get(entity);
+            if (body && body.setLinvel) {
+                body.setLinvel({ x: vel.x, y: vel.y, z: vel.z }, true);
+            }
+        });
+        this.physicsWorld.step();
+        // sync positions back to components
+        this.queries.movers.results.forEach((entity) => {
+            const body = this.bodies.get(entity);
+            if (body && body.translation) {
+                const t = body.translation();
+                const pos = entity.getMutableComponent(Position);
+                pos.x = t.x;
+                pos.y = t.y;
+                pos.z = t.z;
+            }
+        });
+    }
+    stop() {
+        this.bodies.clear();
+    }
+}
+PhysicsSystem.queries = {
+    movers: {
+        components: [Position, Velocity],
+        listen: {
+            added: true,
+        },
+    },
+};

--- a/dist/shims/rapier3d-compat.d.ts
+++ b/dist/shims/rapier3d-compat.d.ts
@@ -1,0 +1,11 @@
+export interface RapierWorld {
+    step(): void;
+}
+declare const _default: {
+    init(): Promise<{
+        World: new (gravity: any) => RapierWorld;
+        RigidBodyDesc: any;
+        RigidBodyType: any;
+    }>;
+};
+export default _default;

--- a/dist/shims/rapier3d-compat.js
+++ b/dist/shims/rapier3d-compat.js
@@ -1,0 +1,15 @@
+export default {
+    async init() {
+        return {
+            World: class {
+                constructor(_gravity) { }
+                step() { }
+            },
+            RigidBodyDesc: class {
+                static newDynamic() { return {}; }
+                setTranslation(_x, _y, _z) { return this; }
+            },
+            RigidBodyType: {},
+        };
+    },
+};

--- a/lib/engine/index.ts
+++ b/lib/engine/index.ts
@@ -4,3 +4,4 @@ export * from "./components/Velocity";
 export * from "./components/Mesh";
 export * from "./systems/MoveSystem";
 export * from "./systems/RenderSystem";
+export * from "./systems/PhysicsSystem";

--- a/lib/engine/systems/PhysicsSystem.ts
+++ b/lib/engine/systems/PhysicsSystem.ts
@@ -1,0 +1,72 @@
+import { System, Entity } from "ecsy";
+import RAPIER from "@dimforge/rapier3d-compat";
+import { Position } from "../components/Position";
+import { Velocity } from "../components/Velocity";
+
+export interface PhysicsSystemConfig {
+  gravity?: { x: number; y: number; z: number };
+}
+
+export class PhysicsSystem extends System {
+  private rapier: any;
+  private physicsWorld: any;
+  private bodies = new Map<Entity, any>();
+
+  async init(attributes?: PhysicsSystemConfig): Promise<void> {
+    this.rapier = await RAPIER.init();
+    const gravity = attributes?.gravity ?? { x: 0, y: -9.81, z: 0 };
+    this.physicsWorld = new this.rapier.World(gravity);
+  }
+
+  execute(_delta: number): void {
+    // create bodies for newly added entities
+    if (this.queries.movers?.added) {
+      this.queries.movers.added.forEach((entity: Entity) => {
+        const pos = entity.getComponent(Position)!;
+        const desc = this.rapier.RigidBodyDesc.newDynamic().setTranslation(
+          pos.x,
+          pos.y,
+          pos.z
+        );
+        const body = this.physicsWorld.createRigidBody(desc);
+        this.bodies.set(entity, body);
+      });
+    }
+
+    // update bodies with velocity from components
+    this.queries.movers.results.forEach((entity: Entity) => {
+      const vel = entity.getComponent(Velocity)!;
+      const body = this.bodies.get(entity);
+      if (body && body.setLinvel) {
+        body.setLinvel({ x: vel.x, y: vel.y, z: vel.z }, true);
+      }
+    });
+
+    this.physicsWorld.step();
+
+    // sync positions back to components
+    this.queries.movers.results.forEach((entity: Entity) => {
+      const body = this.bodies.get(entity);
+      if (body && body.translation) {
+        const t = body.translation();
+        const pos = entity.getMutableComponent(Position)!;
+        pos.x = t.x;
+        pos.y = t.y;
+        pos.z = t.z;
+      }
+    });
+  }
+
+  stop(): void {
+    this.bodies.clear();
+  }
+}
+
+PhysicsSystem.queries = {
+  movers: {
+    components: [Position, Velocity],
+    listen: {
+      added: true,
+    },
+  },
+};

--- a/lib/shims/rapier3d-compat.ts
+++ b/lib/shims/rapier3d-compat.ts
@@ -1,0 +1,13 @@
+export interface RapierWorld {
+  step(): void;
+}
+
+export default {
+  async init(): Promise<{ World: new (gravity: any) => RapierWorld; RigidBodyDesc: any; RigidBodyType: any; }> {
+    return {
+      World: class { constructor(_gravity: any) {} step() {} },
+      RigidBodyDesc: class { static newDynamic(): any { return {}; } setTranslation(_x: number, _y: number, _z: number) { return this; } },
+      RigidBodyType: {},
+    } as any;
+  },
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "three": ["lib/shims/three"]
+      "three": ["lib/shims/three"],
+      "@dimforge/rapier3d-compat": ["lib/shims/rapier3d-compat"]
     }
   },
   "include": ["lib/**/*"],


### PR DESCRIPTION
## Summary
- add PhysicsSystem implemented with Rapier
- stub Rapier module in `lib/shims`
- export PhysicsSystem and add tsconfig path
- build dist outputs

## Testing
- `npm run build`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_6879f235e3ac83308625801dcf52ce85