### PR TITLE
Handle render and physics cleanup

### DIFF
--- a/dist/engine/systems/RapierSystem.d.ts
+++ b/dist/engine/systems/RapierSystem.d.ts
@@ -30,10 +30,13 @@ export declare class RapierSystem extends System<RapierSystemConfig> {
     private accumulator;
     private fixedDelta;
     private maxSubSteps;
+    /** Current number of physics bodies tracked by the system. */
+    bodyCount(): number;
     init(attrs?: RapierSystemConfig): void;
     execute(delta: number): void;
     private addBody;
     private createBoundaryColliders;
     /** Remove the Rapier rigid body and collider for the given entity. */
     removeBody(entity: any): void;
+    dispose(): void;
 }

--- a/dist/engine/systems/RapierSystem.js
+++ b/dist/engine/systems/RapierSystem.js
@@ -32,6 +32,10 @@ export class RapierSystem extends System {
         this.fixedDelta = 1 / 60;
         this.maxSubSteps = 5;
     }
+    /** Current number of physics bodies tracked by the system. */
+    bodyCount() {
+        return this.bodyMap.size;
+    }
     init(attrs) {
         const gravity = attrs?.gravity ?? { x: 0, y: 0, z: 0 };
         this.onCollision = attrs?.onCollision;
@@ -213,6 +217,17 @@ export class RapierSystem extends System {
             this.world.removeRigidBody(body);
             this.bodyMap.delete(entity.id);
         }
+    }
+    dispose() {
+        this.eventQueue?.free();
+        this.eventQueue = null;
+        this.world?.free();
+        this.world = null;
+        this.bodyMap.clear();
+        this.colliderMap.clear();
+        this.entityColliderMap.clear();
+        this.pendingAdds = [];
+        this.pendingRemoves = [];
     }
 }
 RapierSystem.queries = {

--- a/dist/engine/systems/RenderSystem.d.ts
+++ b/dist/engine/systems/RenderSystem.d.ts
@@ -7,6 +7,10 @@ export declare class RenderSystem extends System {
     private camera;
     private renderer;
     private lastPosAt;
+    /** Current number of mesh objects in the scene. */
+    objectCount(): number;
     init(attributes?: RenderSystemConfig): void;
+    private handleRemovals;
     execute(): void;
+    dispose(): void;
 }

--- a/dist/shims/rapier3d-compat.d.ts
+++ b/dist/shims/rapier3d-compat.d.ts
@@ -1,6 +1,7 @@
 export declare class EventQueue {
     constructor(_autoDrain: boolean);
     drainCollisionEvents(_cb: (h1: number, h2: number, started: boolean) => void): void;
+    free(): void;
 }
 export declare const ActiveEvents: {
     COLLISION_EVENTS: number;
@@ -25,7 +26,10 @@ export declare class World {
     step(_queue?: EventQueue): void;
     createRigidBody(_desc: RigidBodyDesc): any;
     createCollider(_desc: ColliderDesc, _body: any): any;
+    getCollider(_handle: number): any;
+    removeCollider(_collider: any, _wakeBody: boolean): void;
     removeRigidBody(_body: any): void;
+    free(): void;
 }
 export type RigidBody = ReturnType<World['createRigidBody']>;
 export type Collider = ReturnType<World['createCollider']>;

--- a/dist/shims/rapier3d-compat.js
+++ b/dist/shims/rapier3d-compat.js
@@ -1,6 +1,7 @@
 export class EventQueue {
     constructor(_autoDrain) { }
     drainCollisionEvents(_cb) { }
+    free() { }
 }
 export const ActiveEvents = {
     COLLISION_EVENTS: 1,
@@ -36,7 +37,10 @@ export class World {
             setActiveEvents(_ev) { },
         };
     }
+    getCollider(_handle) { return { handle: _handle }; }
+    removeCollider(_collider, _wakeBody) { }
     removeRigidBody(_body) { }
+    free() { }
 }
 const DefaultExport = {
     async init() { return DefaultExport; },

--- a/dist/shims/three.d.ts
+++ b/dist/shims/three.d.ts
@@ -1,6 +1,8 @@
 export declare class Scene {
     children: any[];
     add(obj: any): void;
+    remove(obj: any): void;
+    clear(): void;
 }
 export declare class PerspectiveCamera {
     fov: number;
@@ -20,6 +22,7 @@ export declare class WebGLRenderer {
     constructor(options?: any);
     setSize(_w: number, _h: number): void;
     render(_scene: any, _camera: any): void;
+    dispose(): void;
 }
 export declare class Mesh {
     constructor(_geometry?: any, _material?: any);

--- a/dist/shims/three.js
+++ b/dist/shims/three.js
@@ -7,6 +7,14 @@ export class Scene {
             this.children.push(obj);
         }
     }
+    remove(obj) {
+        const i = this.children.indexOf(obj);
+        if (i >= 0)
+            this.children.splice(i, 1);
+    }
+    clear() {
+        this.children = [];
+    }
 }
 export class PerspectiveCamera {
     constructor(fov, aspect, near, far) {
@@ -32,6 +40,7 @@ export class WebGLRenderer {
     }
     setSize(_w, _h) { }
     render(_scene, _camera) { }
+    dispose() { }
 }
 export class Mesh {
     constructor(_geometry, _material) {

--- a/lib/engine/systems/RapierSystem.ts
+++ b/lib/engine/systems/RapierSystem.ts
@@ -47,6 +47,11 @@ export class RapierSystem extends System<RapierSystemConfig> {
   private fixedDelta = 1 / 60;
   private maxSubSteps = 5;
 
+  /** Current number of physics bodies tracked by the system. */
+  bodyCount(): number {
+    return this.bodyMap.size;
+  }
+
   init(attrs?: RapierSystemConfig): void {
     const gravity = attrs?.gravity ?? { x: 0, y: 0, z: 0 };
     this.onCollision = attrs?.onCollision;
@@ -232,6 +237,18 @@ export class RapierSystem extends System<RapierSystemConfig> {
       (this.world as any).removeRigidBody(body);
       this.bodyMap.delete(entity.id);
     }
+  }
+
+  dispose(): void {
+    this.eventQueue?.free();
+    this.eventQueue = null;
+    this.world?.free();
+    this.world = null;
+    this.bodyMap.clear();
+    this.colliderMap.clear();
+    this.entityColliderMap.clear();
+    this.pendingAdds = [];
+    this.pendingRemoves = [];
   }
 }
 

--- a/lib/shims/rapier3d-compat.ts
+++ b/lib/shims/rapier3d-compat.ts
@@ -1,6 +1,7 @@
 export class EventQueue {
   constructor(_autoDrain: boolean) {}
   drainCollisionEvents(_cb: (h1: number, h2: number, started: boolean) => void): void {}
+  free(): void {}
 }
 
 export const ActiveEvents = {
@@ -39,7 +40,10 @@ export class World {
       setActiveEvents(_ev: number) {},
     } as any;
   }
+  getCollider(_handle: number): any { return { handle: _handle }; }
+  removeCollider(_collider: any, _wakeBody: boolean): void {}
   removeRigidBody(_body: any): void {}
+  free(): void {}
 }
 
 // Types used by `import type * as RAPIERType from '@dimforge/rapier3d-compat'`

--- a/lib/shims/three.ts
+++ b/lib/shims/three.ts
@@ -5,6 +5,13 @@ export class Scene {
       this.children.push(obj);
     }
   }
+  remove(obj: any): void {
+    const i = this.children.indexOf(obj);
+    if (i >= 0) this.children.splice(i, 1);
+  }
+  clear(): void {
+    this.children = [];
+  }
 }
 
 export class PerspectiveCamera {
@@ -25,6 +32,7 @@ export class WebGLRenderer {
   constructor(public options: any = {}) {}
   setSize(_w: number, _h: number): void {}
   render(_scene: any, _camera: any): void {}
+  dispose(): void {}
 }
 
 export class Mesh {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev": "tsc -w",
     "clean": "rm -rf dist",
     "lint": "eslint lib/**/*.ts",
+    "test": "node --experimental-specifier-resolution=node --loader ./tests/loader.mjs --test",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run lint && npm run typecheck && npm run build",
     "release": "npm version patch",

--- a/tests/cleanup.test.js
+++ b/tests/cleanup.test.js
@@ -1,0 +1,68 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { World } from 'ecsy';
+import { RenderSystem } from '../dist/engine/systems/RenderSystem.js';
+import { RapierSystem } from '../dist/engine/systems/RapierSystem.js';
+import { Position } from '../dist/engine/components/Position.js';
+import { MeshComponent } from '../dist/engine/components/Mesh.js';
+import { Mesh } from 'three';
+import { Velocity } from '../dist/engine/components/Velocity.js';
+import { Collider } from '../dist/engine/components/Collider.js';
+
+test('RenderSystem removes meshes when entities are deleted', () => {
+  const world = new World();
+  world
+    .registerComponent(Position)
+    .registerComponent(MeshComponent)
+    .registerSystem(RenderSystem);
+
+  const mesh = new Mesh();
+  const entity = world
+    .createEntity()
+    .addComponent(Position, { x: 1, y: 2, z: 3, updatedAt: 0 })
+    .addComponent(MeshComponent, { mesh });
+
+  const renderSystem = world.getSystem(RenderSystem);
+
+  world.execute(0);
+  assert.equal(renderSystem.objectCount(), 1);
+
+  entity.remove();
+  world.execute(0);
+  assert.equal(renderSystem.objectCount(), 0);
+
+  renderSystem.dispose();
+  assert.equal(renderSystem.objectCount(), 0);
+});
+
+test('RapierSystem removes bodies when entities are deleted', async () => {
+  const world = new World();
+  world
+    .registerComponent(Position)
+    .registerComponent(Velocity)
+    .registerComponent(Collider)
+    .registerSystem(RapierSystem);
+
+  const rapierSystem = world.getSystem(RapierSystem);
+
+  while (!rapierSystem.world) {
+    await new Promise(r => setTimeout(r, 0));
+  }
+
+  const entity = world
+    .createEntity()
+    .addComponent(Position)
+    .addComponent(Velocity)
+    .addComponent(Collider, { size: 1 });
+
+  world.execute(0);
+  assert.equal(rapierSystem.bodyCount(), 1);
+
+  entity.remove();
+  world.execute(0);
+  world.execute(0);
+  assert.equal(rapierSystem.bodyCount(), 0);
+
+  rapierSystem.dispose();
+  assert.equal(rapierSystem.bodyCount(), 0);
+});

--- a/tests/loader.mjs
+++ b/tests/loader.mjs
@@ -1,0 +1,15 @@
+export async function resolve(specifier, context, defaultResolve) {
+  if (specifier === 'three') {
+    return { url: new URL('../dist/shims/three.js', import.meta.url).href, shortCircuit: true };
+  }
+  if (specifier === '@dimforge/rapier3d-compat') {
+    return { url: new URL('../dist/shims/rapier3d-compat.js', import.meta.url).href, shortCircuit: true };
+  }
+  if ((specifier.startsWith('./') || specifier.startsWith('../')) && !specifier.endsWith('.js')) {
+    return {
+      url: new URL(specifier + '.js', context.parentURL).href,
+      shortCircuit: true,
+    };
+  }
+  return defaultResolve(specifier, context, defaultResolve);
+}


### PR DESCRIPTION
## Summary
- track and remove meshes when entities disappear
- expose object counts and disposal for renderer and rapier systems
- extend shims to support new cleanup methods
- add tests covering render and physics resource cleanup

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b6624636648330890f2287260e982d